### PR TITLE
fix(navbar): remove NavbarMenu when closed

### DIFF
--- a/.changeset/nice-beds-battle.md
+++ b/.changeset/nice-beds-battle.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/navbar": patch
+---
+
+fixed NavbarMenu React.Fragment prop error when animation is disabled (#4501)

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -32,25 +32,28 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
 
   const styles = clsx(classNames?.menu, className);
 
-  // only apply overlay when menu is open
-  const OverlayComponent = isMenuOpen ? Overlay : React.Fragment;
+  if (disableAnimation) {
+    if (!isMenuOpen) return null;
 
-  const contents = disableAnimation ? (
-    <OverlayComponent portalContainer={portalContainer}>
-      <ul
-        ref={domRef}
-        className={slots.menu?.({class: styles})}
-        data-open={dataAttr(isMenuOpen)}
-        style={{
-          // @ts-expect-error
-          "--navbar-height": typeof height === "number" ? `${height}px` : height,
-        }}
-        {...otherProps}
-      >
-        {children}
-      </ul>
-    </OverlayComponent>
-  ) : (
+    return (
+      <Overlay portalContainer={portalContainer}>
+        <ul
+          ref={domRef}
+          className={slots.menu?.({class: styles})}
+          data-open={dataAttr(isMenuOpen)}
+          style={{
+            // @ts-expect-error
+            "--navbar-height": typeof height === "number" ? `${height}px` : height,
+          }}
+          {...otherProps}
+        >
+          {children}
+        </ul>
+      </Overlay>
+    );
+  }
+
+  return (
     <AnimatePresence mode="wait">
       {isMenuOpen ? (
         <Overlay portalContainer={portalContainer}>
@@ -78,8 +81,6 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
       ) : null}
     </AnimatePresence>
   );
-
-  return contents;
 });
 
 NavbarMenu.displayName = "NextUI.NavbarMenu";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4501

## 📝 Description

- if animation is enabled, NavbarMenu is not in the DOM when menu is closed
- if animation is disabled, NavbarMenu is in the DOM but has `display: none`
- could not think of any particular reason not to remove NavbarMenu from DOM when menu is closed
  - shouldn't affect accessibility since it was using `display: none` when closed

## ⛳️ Current behavior (updates)

no actual behaviour changes

![Screenshot 2025-01-07 at 14 25 17](https://github.com/user-attachments/assets/2fad0c50-94b3-4917-81a1-77b7f71399e0)



## 🚀 New behavior

no actual behaviour changes, console error fixed

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an error in the `NavbarMenu` component of the `@nextui-org/navbar` package
	- Fixed rendering issues when animations are disabled
	- Improved component stability and rendering logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->