### PR TITLE
Fix forgotten Rebranding Text & broken Link

### DIFF
--- a/apps/docs/components/footer.tsx
+++ b/apps/docs/components/footer.tsx
@@ -20,7 +20,7 @@ export const Footer = () => {
     <footer className="container mx-auto max-w-7xl pb-12 px-12">
       <div className="flex flex-col justify-center items-center gap-1">
         <p className="text-sm text-default-400">
-          © {getCurrentYear()} NextUI Inc. All rights reserved.
+          © {getCurrentYear()} HeroUI Inc. All rights reserved.
         </p>
         {isDocs ? (
           <div className="flex items-center gap-1">

--- a/apps/docs/components/footer.tsx
+++ b/apps/docs/components/footer.tsx
@@ -20,7 +20,7 @@ export const Footer = () => {
     <footer className="container mx-auto max-w-7xl pb-12 px-12">
       <div className="flex flex-col justify-center items-center gap-1">
         <p className="text-sm text-default-400">
-          © {getCurrentYear()} HeroUI Inc. All rights reserved.
+          © {getCurrentYear()} NextUI Inc. All rights reserved.
         </p>
         {isDocs ? (
           <div className="flex items-center gap-1">

--- a/apps/docs/components/navbar.tsx
+++ b/apps/docs/components/navbar.tsx
@@ -100,11 +100,9 @@ export const Navbar: FC<NavbarProps> = ({children, routes, mobileRoutes = [], sl
   );
 
   const handleVersionChange = useCallback((key: Key) => {
-    if (key === "v1") {
-      const newWindow = window.open("https://v1.heroui.com", "_blank", "noopener,noreferrer");
+      const newWindow = window.open(`https://${key ? `${key}.` : ""}heroui.com`, "_blank", "noopener,noreferrer");
 
       if (newWindow) newWindow.opener = null;
-    }
   }, []);
 
   const handlePressNavbarItem = useCallback(
@@ -172,9 +170,6 @@ export const Navbar: FC<NavbarProps> = ({children, routes, mobileRoutes = [], sl
           onAction={handleVersionChange}
         >
           <DropdownItem key="v2">v{currentVersion}</DropdownItem>
-          <DropdownItem key="v1" endContent={<LinkIcon />}>
-            v1.0.0
-          </DropdownItem>
         </DropdownMenu>
       </Dropdown>
     ) : (


### PR DESCRIPTION
## 📝 Description & ## ⛳️ Current behavior
Currently there still is the old name NextUI in the Footer. I replaced it with the Name HeroUI.
Aswell there is a Version Selector in the Navbar, the v1. Link is broken.

## 🚀 New behavior
The Footer has now the adjusted text HeroUI.
The Version Selector switch function is now able to redirect to v.xx. URLs if you add new Selector Values.

## 💣 Is this a breaking change (Yes/No): No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Branding**
	- Updated footer copyright from "NextUI Inc." to "HeroUI Inc."

- **Navigation**
	- Improved version handling in navbar
	- Removed specific "v1" version dropdown option
	- Enhanced version selection flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->