### PR TITLE
docs(installation): Update Hoisted dependencies step to help users with Prettier/EsLint

### DIFF
--- a/apps/docs/content/docs/guide/installation.mdx
+++ b/apps/docs/content/docs/guide/installation.mdx
@@ -151,6 +151,13 @@ If you are using pnpm, you need to add the following line to your `.npmrc` file 
 ```bash
 public-hoist-pattern[]=*@heroui/*
 ```
+If you are using Prettier and/or EsLint include them accordingly.
+
+```bash
+public-hoist-pattern[]=*@heroui/*
+public-hoist-pattern[]=*eslint*
+public-hoist-pattern[]=*prettier*
+```
 
 After modifying the `.npmrc` file, you need to run `pnpm install` again to ensure that the dependencies are installed correctly.
 


### PR DESCRIPTION
## 📝 Description
Updated Hoisted dependencies step in installation.mdx.
Added extra information about hoisted pnpm packages. Because without prior knowledge about hoisting you may end up with broken Prettier and EsLint.  Read more here: https://github.com/pnpm/pnpm/issues/8878

## ⛳️ Current behavior (updates)

Docs don't inform new users that their Prettier and EsLint may stop working because of how Pnpm and hoisting works.

## 🚀 New behavior

Now the user will have the information needed to prevent non-working Prettier and EsLint. 

## 💣 Is this a breaking change (Yes/No): No
